### PR TITLE
Significant acceleration of gradient norms

### DIFF
--- a/CANGAMetricsDriver.py
+++ b/CANGAMetricsDriver.py
@@ -306,7 +306,7 @@ def loadDataField(ncFieldFileHnd, varName, dimension):
 def loadFieldGradient(varField, varConn, varCoord, varConStenDex, jacobians, numCells, SpectralElement):
        
        start = time.time()
-       print('Computing or reading gradients for target sampled and regridded fields...')
+       # print('Computing or reading gradients for target sampled and regridded fields...')
         
        # Read in previously stored ST data if it exists, or compute it and store
        if SpectralElement:
@@ -319,7 +319,7 @@ def loadFieldGradient(varField, varConn, varCoord, varConStenDex, jacobians, num
               gradField = computeGradientFV3(varField, varConn, varCoord, varConStenDex)
 
        endt = time.time()
-       print('Time to compute/read gradients on target mesh (sec): ', endt - start)
+       # print('Time to compute/read gradients on target mesh (sec): ', endt - start)
        
        return gradField
        

--- a/CANGAMetricsDriver.py
+++ b/CANGAMetricsDriver.py
@@ -465,6 +465,18 @@ if __name__ == '__main__':
        # Open the .nc data files for reading
        ncFieldFileHnd = Dataset(fieldDataFile, 'r')
 
+       # Read in or compute the respective gradients on target mesh
+       if includeGradientMetrics:
+              print('\nComputing gradient datastructures for grids...')
+              start = time.time()
+              gradSCtx = ComputeGradientFV('Source', varConS, varCoordS, varConStenDexS, nprocs)
+              gradSCtx.precomputeGradientFV3Data()
+              print('Time taken to precompute gradient datastructures for source grid: ', time.time() - start)
+              start = time.time()
+              gradTCtx = ComputeGradientFV('Target', varConT, varCoordT, varConStenDexT, nprocs)
+              gradTCtx.precomputeGradientFV3Data()
+              print('Time taken to precompute gradient datastructures for target grid: ', time.time() - start)
+
        for fieldName in fieldNames:
 
             print('\nComputing Field metrics for ', fieldName)
@@ -474,16 +486,7 @@ if __name__ == '__main__':
 
             # Read in or compute the respective gradients on target mesh
             if includeGradientMetrics:
-                   print('\nComputing gradient datastructures for grids...')
-                   start = time.time()
-                   gradSCtx = ComputeGradientFV('Source', varConS, varCoordS, varConStenDexS, nprocs)
-                   gradSCtx.precomputeGradientFV3Data()
-                   print('Time taken to precompute gradient datastructures for source grid: ', time.time() - start)
                    gradTS = loadFieldGradient(gradSCtx, varSS, varConS, varCoordS, varConStenDexS, jacobiansS, numCellsS, isSourceSpectralElementMesh)
-                   start = time.time()
-                   gradTCtx = ComputeGradientFV('Target', varConT, varCoordT, varConStenDexT, nprocs)
-                   gradTCtx.precomputeGradientFV3Data()
-                   print('Time taken to precompute gradient datastructures for target grid: ', time.time() - start)
                    gradST = loadFieldGradient(gradTCtx, varST, varConT, varCoordT, varConStenDexT, jacobiansT, numCellsT, isTargetSpectralElementMesh)
 
             #%%

--- a/CANGAMetricsDriver.py
+++ b/CANGAMetricsDriver.py
@@ -307,8 +307,6 @@ def loadDataField(ncFieldFileHnd, varName, dimension):
 def loadFieldGradient(gradCtx, varField, varConn, varCoord, varConStenDex, jacobians, numCells, SpectralElement):
        
        start = time.time()
-       print('Computing or reading gradients for target sampled and regridded fields...')
-        
        # Read in previously stored ST data if it exists, or compute it and store
        if SpectralElement:
               # This comes from mesh preprocessing
@@ -321,7 +319,7 @@ def loadFieldGradient(gradCtx, varField, varConn, varCoord, varConStenDex, jacob
               gradField = gradCtx.computeGradientFV3(varField)
 
        endt = time.time()
-       print('Time to compute/read gradients on given mesh (sec): ', endt - start)
+       # print('Time to compute/read gradients on', gradCtx.context, 'mesh (sec): ', endt - start)
        
        return gradField
        
@@ -470,15 +468,16 @@ if __name__ == '__main__':
 
             # Read in or compute the respective gradients on target mesh
             if includeGradientMetrics:
-                   gradSCtx = ComputeGradientFV(varConS, varCoordS, varConStenDexS)
+                   print('\nComputing gradient datastructures for grids...')
                    start = time.time()
+                   gradSCtx = ComputeGradientFV('Source', varConS, varCoordS, varConStenDexS)
                    gradSCtx.precomputeGradientFV3Data()
-                   print('Time taken to precompute datastructures for source grid: ', time.time() - start)
+                   print('Time taken to precompute gradient datastructures for source grid: ', time.time() - start)
                    gradTS = loadFieldGradient(gradSCtx, varSS, varConS, varCoordS, varConStenDexS, jacobiansS, numCellsS, isSourceSpectralElementMesh)
                    start = time.time()
-                   gradTCtx = ComputeGradientFV(varConT, varCoordT, varConStenDexT)
+                   gradTCtx = ComputeGradientFV('Target', varConT, varCoordT, varConStenDexT)
                    gradTCtx.precomputeGradientFV3Data()
-                   print('Time taken to precompute datastructures for target grid: ', time.time() - start)
+                   print('Time taken to precompute gradient datastructures for target grid: ', time.time() - start)
                    gradST = loadFieldGradient(gradTCtx, varST, varConT, varCoordT, varConStenDexT, jacobiansT, numCellsT, isTargetSpectralElementMesh)
 
             #%%

--- a/CANGAMetricsDriver.py
+++ b/CANGAMetricsDriver.py
@@ -350,6 +350,9 @@ if __name__ == '__main__':
 
        # Max number of remap iteration solutions to use in order to compute the metrics
        maxRemapIterations = 1
+
+       # Parallelization of the driver through multiprocessing
+       nprocs = 1
        
        def print_usage():
               print('Command line not properly set:', \
@@ -364,7 +367,8 @@ if __name__ == '__main__':
                     '--output <metricsFileName>', \
                     '--<includeGradientMetrics>', \
                     '--<isSourceSpectralElementMesh>', \
-                    '--<isTargetSpectralElementMesh>')
+                    '--<isTargetSpectralElementMesh>', \
+                    '--processes <nprocs>')
        
        try:
               opts, args = getopt.getopt(sys.argv[1:], 'hv:', \
@@ -372,7 +376,7 @@ if __name__ == '__main__':
                                          'smc=', 'tmc=', \
                                          'dimension=', 'includeGradientMetrics', \
                                          'output=', \
-                                         'isSourceSpectralElementMesh', 'isTargetSpectralElementMesh'])
+                                         'isSourceSpectralElementMesh', 'isTargetSpectralElementMesh', 'processes='])
        except getopt.GetoptError:
               print_usage()
               sys.exit(2)
@@ -404,6 +408,8 @@ if __name__ == '__main__':
                      maxRemapIterations = int(arg)
               elif opt == '--output':
                      outputMetricsFile = arg
+              elif opt == '--processes':
+                     nprocs = int(arg)
 
        # Input checks
        if sourceMeshConfig > 3:
@@ -470,12 +476,12 @@ if __name__ == '__main__':
             if includeGradientMetrics:
                    print('\nComputing gradient datastructures for grids...')
                    start = time.time()
-                   gradSCtx = ComputeGradientFV('Source', varConS, varCoordS, varConStenDexS)
+                   gradSCtx = ComputeGradientFV('Source', varConS, varCoordS, varConStenDexS, nprocs)
                    gradSCtx.precomputeGradientFV3Data()
                    print('Time taken to precompute gradient datastructures for source grid: ', time.time() - start)
                    gradTS = loadFieldGradient(gradSCtx, varSS, varConS, varCoordS, varConStenDexS, jacobiansS, numCellsS, isSourceSpectralElementMesh)
                    start = time.time()
-                   gradTCtx = ComputeGradientFV('Target', varConT, varCoordT, varConStenDexT)
+                   gradTCtx = ComputeGradientFV('Target', varConT, varCoordT, varConStenDexT, nprocs)
                    gradTCtx.precomputeGradientFV3Data()
                    print('Time taken to precompute gradient datastructures for target grid: ', time.time() - start)
                    gradST = loadFieldGradient(gradTCtx, varST, varConT, varCoordT, varConStenDexT, jacobiansT, numCellsT, isTargetSpectralElementMesh)

--- a/CANGAMetricsDriver.py
+++ b/CANGAMetricsDriver.py
@@ -502,7 +502,7 @@ if __name__ == '__main__':
 
             # Print out a table with metric results. Let us print progress during iteration progress
             print('\n')
-            printProgressBar(0, maxRemapIterations, prefix = 'Progress:', suffix = 'Complete', length = 50)
+            printProgressBar(0, maxRemapIterations+1, prefix = 'Progress:', suffix = 'Complete', length = 50)
 
             for iteration in range(maxRemapIterations+1):
                     # Read in field variable data
@@ -563,7 +563,7 @@ if __name__ == '__main__':
 
                     #%%
                     # Print out a table with metric results
-                    printProgressBar(iteration + 1, maxRemapIterations, prefix = 'Progress:', suffix = 'Complete', length = 50)
+                    printProgressBar(iteration+1, maxRemapIterations+1, prefix = 'Progress:', suffix = 'Complete', length = 50)
 
 
             def append_fieldname(filename):

--- a/computeGradientFV3.py
+++ b/computeGradientFV3.py
@@ -17,124 +17,151 @@ import math as mt
 from computeAreaIntegral import computeAreaIntegral
 from computeCentroid import computeCentroid
 
+import multiprocessing
+from multiprocessing import Process
+from itertools import repeat
+
+
+def computeGradientFV3_Private(NC, NP, jj, varField, varCon, varCoords, varStenDex, radius, cellCoords):
+      SF = np.float64
+       
+      # Gradients are 3 component vectors
+      nc = 3
+       
+      # Set the main return variable
+      # varGradient = np.zeros(nc, dtype=SF)
+
+      # Loop over the cells
+      # for jj in range(NC):
+      pdex = np.array(range(NP), dtype = int)
+      
+      # Check for local degeneracy in stencil and fix connectivity
+      for pp in range(NP):
+              # Look for -1 in the adjacency stencil
+              if varStenDex[jj,pp] <= 0:
+                    pdex = np.delete(pdex, pp)
+              else:
+                    continue
+              
+      # Make pdex periodic
+      pdexp = np.append(pdex, pdex[0])
+      
+      # Fetch the modified stencil
+      thisStencil = varStenDex[jj,pdexp]
+      
+      # Initialize the new convex hull stencil
+      convHullSten = varStenDex[jj,pdex]
+      
+      # Build the convex hull of cells around this cell
+      for pp in range(len(convHullSten)):
+              # Fetch consecutive pairs of cell id
+              cid1 = thisStencil[pp] - 1
+              cid2 = thisStencil[pp+1] - 1
+              
+              # Fetch consecutive pairs of stencils
+              stn1 = varStenDex[cid1.astype(int),:]
+              stn2 = varStenDex[cid2.astype(int),:]
+              
+              # Get the set intersection
+              commonIds = list(set(stn1).intersection(stn2))
+              # Get the common cell that is NOT the current target cell
+              newCellId = [x for x in commonIds if x != jj+1]
+              
+              # Check new cell ID to be of length 1
+              if len(newCellId) != 1:
+                    # print('Found no neighboring cell or multiples in stencil!')
+                    # print('New cell will NOT be recorded to the convex hull at cell: ', jj+1)
+                    continue
+              
+              # Insert the new cell ID
+              np.insert(convHullSten, pp+1, newCellId[0].astype(int))
+      
+      # Loop over the convex hull stencil and get dual edges map
+      NS = len(convHullSten)
+      fluxIntegral = np.zeros(nc, dtype=SF)
+      dualEdgeMap = np.zeros((nc,NS))
+      boundaryNorm = np.zeros((nc,NS))
+      boundaryAngles = np.zeros((NS,1))
+      for pp in range(NS):
+              # Fetch the dual edge and store
+              sid1 = convHullSten[pp] - 1
+              sid1 = sid1.astype(int)
+              # Make the dual polygon convex
+              if pp == len(pdex) - 1:
+                    sid2 = convHullSten[0] - 1
+              else:
+                    sid2 = convHullSten[pp+1] - 1
+              sid2 = sid2.astype(int)
+              
+              # Store the dual mesh polygon
+              dualEdgeMap[:,pp] = cellCoords[:,sid1]
+              
+              # Compute angles spanned by each boundary segment
+              RE = 0.5 * (radius[sid1] + radius[sid2])
+              unCoord1 = 1.0 / radius[sid1] * cellCoords[:,sid1]
+              unCoord2 = 1.0 / radius[sid2] * cellCoords[:,sid2]
+              boundaryAngles[pp] = mt.acos(np.dot(unCoord1, unCoord2))
+              boundaryAngles[pp] = abs(boundaryAngles[pp])
+              
+              # Compute the stencil boundary normals
+              boundaryNorm[:,pp] = np.cross(cellCoords[:,sid2], \
+                                            cellCoords[:,sid1])
+              bnMag = np.linalg.norm(boundaryNorm[:,pp])
+              boundaryNorm[:,pp] = 1.0 / bnMag * boundaryNorm[:,pp]
+              
+              # Compute the weighted average of the two cell values AT the shared edge location
+              vWeight = 0.5 * boundaryAngles[pp] * RE
+              varAvg = varField[sid1] + varField[sid2]
+              
+              # Compute the integral over this edge
+              fluxIntegral = np.add(fluxIntegral, \
+                                vWeight * varAvg * \
+                                boundaryNorm[:,pp])
+                
+      # Compute the dual polygon area
+      areaD = computeAreaIntegral(None, dualEdgeMap, 6, False, True)
+      
+      # Compute the local gradient at this cell
+      varGradient = 1.0 / areaD * fluxIntegral
+
+      return varGradient#, areaD
+
 def computeGradientFV3(varField, varCon, varCoords, varStenDex):
-       SF = np.float64
-       
-       # Gradients are 3 component vectors
-       nc = 3
-       gradShape = (nc, varField.shape[0])
-       
-       # Set the main return variable
-       varGradient = np.zeros(gradShape, dtype=SF)
-       
-       cellCoords = np.zeros((nc, varCon.shape[0]), dtype=SF)
-       
-       NC = int(varStenDex.shape[0])
-       NP = int(varStenDex.shape[1])
-       fluxIntegral = np.zeros(nc, dtype=SF)
-       
-       # Precompute the cell centroid map
-       cellCoords = np.zeros((nc,NC), dtype=SF)
-       radius = np.zeros((NC,1), dtype=SF)
-       for jj in range(NC):
-              #pdex = np.array(range(NP), dtype = int)
-              cdex = (varCon[jj,:]) - 1
-              cdex = cdex.astype(int)
-              cell = varCoords[:,cdex]
-              cellCoords[:,jj] = computeCentroid(NP, cell)
-              radius[jj] = np.linalg.norm(cellCoords[:,jj])
-       
-       # Loop over the cells
-       for jj in range(NC):
-              pdex = np.array(range(NP), dtype = int)
-              
-              # Check for local degeneracy in stencil and fix connectivity
-              for pp in range(NP):
-                     # Look for -1 in the adjacency stencil
-                     if varStenDex[jj,pp] <= 0:
-                            pdex = np.delete(pdex, pp)
-                     else:
-                            continue
-                     
-              # Make pdex periodic
-              pdexp = np.append(pdex, pdex[0])
-              
-              # Fetch the modified stencil
-              thisStencil = varStenDex[jj,pdexp]
-              
-              # Initialize the new convex hull stencil
-              convHullSten = varStenDex[jj,pdex]
-              
-              # Build the convex hull of cells around this cell
-              for pp in range(len(convHullSten)):
-                     # Fetch consecutive pairs of cell id
-                     cid1 = thisStencil[pp] - 1
-                     cid2 = thisStencil[pp+1] - 1
-                     
-                     # Fetch consecutive pairs of stencils
-                     stn1 = varStenDex[cid1.astype(int),:]
-                     stn2 = varStenDex[cid2.astype(int),:]
-                     
-                     # Get the set intersection
-                     commonIds = list(set(stn1).intersection(stn2))
-                     # Get the common cell that is NOT the current target cell
-                     newCellId = [x for x in commonIds if x != jj+1]
-                     
-                     # Check new cell ID to be of length 1
-                     if len(newCellId) != 1:
-                            print('Found no neighboring cell or multiples in stencil!')
-                            print('New cell will NOT be recorded to the convex hull at cell: ', jj+1)
-                            continue
-                     
-                     # Insert the new cell ID
-                     np.insert(convHullSten, pp+1, newCellId[0].astype(int))
-              
-              # Loop over the convex hull stencil and get dual edges map
-              NS = len(convHullSten)
-              fluxIntegral = np.zeros(nc, dtype=SF)
-              dualEdgeMap = np.zeros((nc,NS))
-              boundaryNorm = np.zeros((nc,NS))
-              boundaryAngles = np.zeros((NS,1))
-              for pp in range(NS):
-                     # Fetch the dual edge and store
-                     sid1 = convHullSten[pp] - 1
-                     sid1 = sid1.astype(int)
-                     # Make the dual polygon convex
-                     if pp == len(pdex) - 1:
-                            sid2 = convHullSten[0] - 1
-                     else:
-                            sid2 = convHullSten[pp+1] - 1
-                     sid2 = sid2.astype(int)
-                     
-                     # Store the dual mesh polygon
-                     dualEdgeMap[:,pp] = cellCoords[:,sid1]
-                     
-                     # Compute angles spanned by each boundary segment
-                     RE = 0.5 * (radius[sid1] + radius[sid2])
-                     unCoord1 = 1.0 / radius[sid1] * cellCoords[:,sid1]
-                     unCoord2 = 1.0 / radius[sid2] * cellCoords[:,sid2]
-                     boundaryAngles[pp] = mt.acos(np.dot(unCoord1, unCoord2))
-                     boundaryAngles[pp] = abs(boundaryAngles[pp])
-                     
-                     # Compute the stencil boundary normals
-                     boundaryNorm[:,pp] = np.cross(cellCoords[:,sid2], \
-                                                   cellCoords[:,sid1])
-                     bnMag = np.linalg.norm(boundaryNorm[:,pp])
-                     boundaryNorm[:,pp] = 1.0 / bnMag * boundaryNorm[:,pp]
-                     
-                     # Compute the weighted average of the two cell values AT the shared edge location
-                     vWeight = 0.5 * boundaryAngles[pp] * RE
-                     varAvg = varField[sid1] + varField[sid2]
-                     
-                     # Compute the integral over this edge
-                     fluxIntegral = np.add(fluxIntegral, \
-                                        vWeight * varAvg * \
-                                        boundaryNorm[:,pp])
-                        
-              # Compute the dual polygon area
-              areaD = computeAreaIntegral(None, dualEdgeMap, 6, False, True)
-              
-              # Compute the local gradient at this cell
-              varGradient[:,jj] = 1.0 / areaD * fluxIntegral
-              
-       return varGradient
+    SF = np.float64
+    
+    # Gradients are 3 component vectors
+    nc = 3
+    
+    # Set the main return variable
+    
+    cellCoords = np.zeros((nc, varCon.shape[0]), dtype=SF)
+    
+    NC = int(varStenDex.shape[0])
+    NP = int(varStenDex.shape[1])
+    # areaD = np.zeros(NC, dtype=SF)
+    
+    # Precompute the cell centroid map
+    cellCoords = np.zeros((nc,NC), dtype=SF)
+    radius = np.zeros((NC,1), dtype=SF)
+    for jj in range(NC):
+          #pdex = np.array(range(NP), dtype = int)
+          cdex = (varCon[jj,:]) - 1
+          cdex = cdex.astype(int)
+          cell = varCoords[:,cdex]
+          cellCoords[:,jj] = computeCentroid(NP, cell)
+          radius[jj] = np.linalg.norm(cellCoords[:,jj])
+    
+    # Loop over each cell and get cell average
+    pool = multiprocessing.Pool(processes=64)
+    results = pool.starmap(computeGradientFV3_Private, zip(repeat(NC), repeat(NP), range(NC), repeat(varField), repeat(varCon), repeat(varCoords), repeat(varStenDex), repeat(radius), repeat(cellCoords)))
+    pool.close()
+    pool.join()
+    #print(results)
+    varGradient = np.reshape(np.array(results, dtype='f8').T, (nc, varField.shape[0]))
+    #areaD  = np.array(results, dtype='f8')[:, 1]
+
+    # print(varGradient)
+
+    return varGradient
+
+

--- a/computeGradientFV3.py
+++ b/computeGradientFV3.py
@@ -25,12 +25,13 @@ from itertools import repeat
 
 class ComputeGradientFV:
 
-      def __init__(self, varCon, varCoords, varStenDex, NPROCS=4):
+      def __init__(self, ctx, varCon, varCoords, varStenDex, NPROCS=4):
             ## Precompute key datastructures
             self.varCon = varCon
             self.varCoords = varCoords
             self.varStenDex = varStenDex
             self.NPROCS = NPROCS
+            self.context = ctx
 
             # Precompute the cell centroid map
             self.cellCoords = sphcrt.computeCentroids(varCon, varCoords).T
@@ -42,17 +43,12 @@ class ComputeGradientFV:
 
       def precomputeGradientFV3Data_Private(self, NC, NP, jj, varCon, varCoords, varStenDex, radius, cellCoords):
             SF = np.float64
-            
+
             # Gradients are 3 component vectors
             nc = 3
-            
-            # Set the main return variable
-            # varGradient = np.zeros(nc, dtype=SF)
 
-            # Loop over the cells
-            # for jj in range(NC):
             pdex = np.array(range(NP), dtype = int)
-            
+
             # Check for local degeneracy in stencil and fix connectivity
             for pp in range(NP):
                   # Look for -1 in the adjacency stencil
@@ -60,40 +56,40 @@ class ComputeGradientFV:
                         pdex = np.delete(pdex, pp)
                   else:
                         continue
-                  
+
             # Make pdex periodic
             pdexp = np.append(pdex, pdex[0])
-            
+
             # Fetch the modified stencil
             thisStencil = varStenDex[jj,pdexp]
-            
+
             # Initialize the new convex hull stencil
             convHullSten = varStenDex[jj,pdex]
-            
+
             # Build the convex hull of cells around this cell
             for pp in range(len(convHullSten)):
                   # Fetch consecutive pairs of cell id
                   cid1 = thisStencil[pp] - 1
                   cid2 = thisStencil[pp+1] - 1
-                  
+
                   # Fetch consecutive pairs of stencils
                   stn1 = varStenDex[cid1.astype(int),:]
                   stn2 = varStenDex[cid2.astype(int),:]
-                  
+
                   # Get the set intersection
                   commonIds = list(set(stn1).intersection(stn2))
                   # Get the common cell that is NOT the current target cell
                   newCellId = [x for x in commonIds if x != jj+1]
-                  
+
                   # Check new cell ID to be of length 1
                   if len(newCellId) != 1:
                         # print('Found no neighboring cell or multiples in stencil!')
                         # print('New cell will NOT be recorded to the convex hull at cell: ', jj+1)
                         continue
-                  
+
                   # Insert the new cell ID
                   np.insert(convHullSten, pp+1, newCellId[0].astype(int))
-            
+
             # Loop over the convex hull stencil and get dual edges map
             NS = len(convHullSten)
             dualEdgeMap = np.zeros((nc,NS))
@@ -111,52 +107,42 @@ class ComputeGradientFV:
                   else:
                         sid2 = convHullSten[pp+1] - 1
                   sid2 = sid2.astype(int)
-                  
+
                   # Store the dual mesh polygon
                   dualEdgeMap[:,pp] = cellCoords[:,sid1]
-                  
+
                   # Compute angles spanned by each boundary segment
                   RE = 0.5 * (radius[sid1] + radius[sid2])
                   unCoord1 = 1.0 / radius[sid1] * cellCoords[:,sid1]
                   unCoord2 = 1.0 / radius[sid2] * cellCoords[:,sid2]
                   boundaryAngles[pp] = mt.acos(np.dot(unCoord1, unCoord2))
                   boundaryAngles[pp] = abs(boundaryAngles[pp])
-                  
+
                   # Compute the stencil boundary normals
                   boundaryNorm[:,pp] = np.cross(cellCoords[:,sid2], \
                                                 cellCoords[:,sid1])
                   bnMag = np.linalg.norm(boundaryNorm[:,pp])
                   boundaryNorm[:,pp] = 1.0 / bnMag * boundaryNorm[:,pp]
-                  
+
                   # Compute the weighted average of the two cell values AT the shared edge location
                   vWeight = 0.5 * boundaryAngles[pp] * RE
-                  #   varAvg = varField[sid1] + varField[sid2]
 
                   sid[pp, 0] = sid1
                   sid[pp, 1] = sid2
 
                   fluxIntegral[:,pp] =  vWeight * boundaryNorm[:,pp]
 
-                  ## VSM: 
-                  ## Store [sid1, sid2, fluxIntegral[pp]]
-                  ##   where fluxIntegral[pp] = [vWeight * boundaryNorm[:,pp]]]
-                  ## Then can compute: varAvg[pp] = varField[sid1] + varField[sid2]
-                  ## And use the weighted addition:  fluxIntegralTotal = np.dot(fluxIntegral, varAvg)
-                  
-                  # Compute the integral over this edge
-                  #   fluxIntegral = np.add(fluxIntegral, \
-                  #                     vWeight * varAvg * \
-                  #                     boundaryNorm[:,pp])
-                  
             # Compute the dual polygon area
             areaD = computeAreaIntegral(None, dualEdgeMap, 6, False, True)
 
-            ## VSM:
-            ## Store 1.0/areaD
-            
-            # Compute the local gradient at this cell
-            # varGradient = 1.0 / areaD * fluxIntegral
-
+            #############
+            #  VSM: 
+            # Store 1/area, [sid1, sid2], fluxIntegral[pp]
+            #   where fluxIntegral[pp] = [vWeight * boundaryNorm[:,pp]]]
+            # Then can compute: varAvg[pp] = varField[sid1] + varField[sid2]
+            # And use the weighted addition:  fluxIntegralTotal = np.dot(fluxIntegral, varAvg) 
+            # to compute the gradient as gradient = fluxIntegralTotal / area
+            #############
             return 1.0 / areaD, sid, fluxIntegral
 
       def precomputeGradientFV3Data(self):
@@ -170,20 +156,18 @@ class ComputeGradientFV:
                   results = pool.starmap(self.precomputeGradientFV3Data_Private, zip(repeat(NC), repeat(NP), range(NC), repeat(self.varCon), repeat(self.varCoords), repeat(self.varStenDex), repeat(self.radius), repeat(self.cellCoords)))
                   pool.close()
                   pool.join()
-                  
-                  print(np.array(results).shape)
 
                   ## Store the data in the local object for future use
                   self.areaInvD = np.zeros(NC, dtype=SF)
                   for elem in range(NC):
                         self.areaInvD[elem] = results[elem][0]
-                        self.sid.append(np.array(results[elem][1], dtype='i4'))# = np.array(results, dtype='i4')[:, 1]
-                        self.fluxIntegral.append(results[elem][2])# = np.array(results, dtype=SF)[:, 2]
+                        self.sid.append(np.array(results[elem][1], dtype='i4'))
+                        self.fluxIntegral.append(results[elem][2])
                   self.cachedData = True
 
       def optimizedComputeGradientFV3_Private(self, varField, areaInvD, sid, fluxIntegral):
             SF = np.float64
-            
+
             # Gradients are 3 component vectors
             nc = 3
 
@@ -191,19 +175,15 @@ class ComputeGradientFV:
             NS = len(sid[:,0])
             fluxIntegralTotal = np.zeros(nc, dtype=SF)
             for pp in range(NS):
-                  
+
                   # Compute the weighted average of the two cell values AT the shared edge location
+                  # VSM: we have precomputed and stored values of sid already
                   varAvg = varField[sid[pp,0]] + varField[sid[pp,1]]
 
-                  ## VSM: 
-                  ## Store [sid1, sid2, fluxIntegral[pp]]
-                  ##   where fluxIntegral[pp] = [vWeight * boundaryNorm[:,pp]]]
-                  ## Then can compute: varAvg[pp] = varField[sid1] + varField[sid2]
-                  ## And use the weighted addition:  fluxIntegralTotal = np.dot(fluxIntegral, varAvg)
-                  
-                  # Compute the integral over this edge
+                  # Compute the integral over this edge as a weighted addition with precomputed
+                  # fluxIntegral on this edge
                   fluxIntegralTotal = np.add(fluxIntegralTotal, varAvg * fluxIntegral[:,pp])
-            
+
             # Compute the local gradient at this cell
             varGradient = areaInvD * fluxIntegralTotal
 
@@ -226,151 +206,5 @@ class ComputeGradientFV:
             computepool.close()
             computepool.join()
             varGradient = np.reshape(np.array(results, dtype=SF).T, (nc, varField.shape[0]))
-            
-            # print(varGradient)
 
             return varGradient
-
-
-      # def computeGradientFV3_Private(self, NC, NP, jj, varField, varCon, varCoords, varStenDex, radius, cellCoords):
-      #       SF = np.float64
-            
-      #       # Gradients are 3 component vectors
-      #       nc = 3
-            
-      #       # Set the main return variable
-      #       # varGradient = np.zeros(nc, dtype=SF)
-
-      #       # Loop over the cells
-      #       # for jj in range(NC):
-      #       pdex = np.array(range(NP), dtype = int)
-            
-      #       # Check for local degeneracy in stencil and fix connectivity
-      #       for pp in range(NP):
-      #             # Look for -1 in the adjacency stencil
-      #             if varStenDex[jj,pp] <= 0:
-      #                   pdex = np.delete(pdex, pp)
-      #             else:
-      #                   continue
-                  
-      #       # Make pdex periodic
-      #       pdexp = np.append(pdex, pdex[0])
-            
-      #       # Fetch the modified stencil
-      #       thisStencil = varStenDex[jj,pdexp]
-            
-      #       # Initialize the new convex hull stencil
-      #       convHullSten = varStenDex[jj,pdex]
-            
-      #       # Build the convex hull of cells around this cell
-      #       for pp in range(len(convHullSten)):
-      #             # Fetch consecutive pairs of cell id
-      #             cid1 = thisStencil[pp] - 1
-      #             cid2 = thisStencil[pp+1] - 1
-                  
-      #             # Fetch consecutive pairs of stencils
-      #             stn1 = varStenDex[cid1.astype(int),:]
-      #             stn2 = varStenDex[cid2.astype(int),:]
-                  
-      #             # Get the set intersection
-      #             commonIds = list(set(stn1).intersection(stn2))
-      #             # Get the common cell that is NOT the current target cell
-      #             newCellId = [x for x in commonIds if x != jj+1]
-                  
-      #             # Check new cell ID to be of length 1
-      #             if len(newCellId) != 1:
-      #                   # print('Found no neighboring cell or multiples in stencil!')
-      #                   # print('New cell will NOT be recorded to the convex hull at cell: ', jj+1)
-      #                   continue
-                  
-      #             # Insert the new cell ID
-      #             np.insert(convHullSten, pp+1, newCellId[0].astype(int))
-            
-      #       # Loop over the convex hull stencil and get dual edges map
-      #       NS = len(convHullSten)
-      #       fluxIntegral = np.zeros(nc, dtype=SF)
-      #       dualEdgeMap = np.zeros((nc,NS))
-      #       boundaryNorm = np.zeros((nc,NS))
-      #       boundaryAngles = np.zeros((NS,1))
-      #       for pp in range(NS):
-      #             # Fetch the dual edge and store
-      #             sid1 = convHullSten[pp] - 1
-      #             sid1 = sid1.astype(int)
-      #             # Make the dual polygon convex
-      #             if pp == len(pdex) - 1:
-      #                   sid2 = convHullSten[0] - 1
-      #             else:
-      #                   sid2 = convHullSten[pp+1] - 1
-      #             sid2 = sid2.astype(int)
-                  
-      #             # Store the dual mesh polygon
-      #             dualEdgeMap[:,pp] = cellCoords[:,sid1]
-                  
-      #             # Compute angles spanned by each boundary segment
-      #             RE = 0.5 * (radius[sid1] + radius[sid2])
-      #             unCoord1 = 1.0 / radius[sid1] * cellCoords[:,sid1]
-      #             unCoord2 = 1.0 / radius[sid2] * cellCoords[:,sid2]
-      #             boundaryAngles[pp] = mt.acos(np.dot(unCoord1, unCoord2))
-      #             boundaryAngles[pp] = abs(boundaryAngles[pp])
-                  
-      #             # Compute the stencil boundary normals
-      #             boundaryNorm[:,pp] = np.cross(cellCoords[:,sid2], \
-      #                                           cellCoords[:,sid1])
-      #             bnMag = np.linalg.norm(boundaryNorm[:,pp])
-      #             boundaryNorm[:,pp] = 1.0 / bnMag * boundaryNorm[:,pp]
-                  
-      #             # Compute the weighted average of the two cell values AT the shared edge location
-      #             vWeight = 0.5 * boundaryAngles[pp] * RE
-      #             varAvg = varField[sid1] + varField[sid2]
-
-      #             ## VSM: 
-      #             ## Store [sid1, sid2, fluxIntegral[pp]]
-      #             ##   where fluxIntegral[pp] = [vWeight * boundaryNorm[:,pp]]]
-      #             ## Then can compute: varAvg[pp] = varField[sid1] + varField[sid2]
-      #             ## And use the weighted addition:  fluxIntegralTotal = np.dot(fluxIntegral, varAvg)
-                  
-      #             # Compute the integral over this edge
-      #             fluxIntegral = np.add(fluxIntegral, \
-      #                               vWeight * varAvg * \
-      #                               boundaryNorm[:,pp])
-                  
-      #       # Compute the dual polygon area
-      #       areaD = computeAreaIntegral(None, dualEdgeMap, 6, False, True)
-
-      #       ## VSM:
-      #       ## Store 1.0/areaD
-            
-      #       # Compute the local gradient at this cell
-      #       varGradient = 1.0 / areaD * fluxIntegral
-
-      #       return varGradient#, areaD
-
-      # def computeGradientFV3Old(self, varField, varCon, varCoords, varStenDex):
-      #       SF = np.float64
-            
-      #       # Gradients are 3 component vectors
-      #       nc = 3
-            
-      #       # Initialize some cache data
-      #       cellCoords = np.zeros((nc, varCon.shape[0]), dtype=SF)
-      #       NC = int(varStenDex.shape[0])
-      #       NP = int(varStenDex.shape[1])
-            
-      #       # Precompute the cell centroid map
-      #       cellCoords = sphcrt.computeCentroids(varCon, varCoords).T
-      #       radius = np.linalg.norm(cellCoords, axis=0)
-
-      #       # Loop over each cell and get cell average
-      #       pool = multiprocessing.Pool(processes=4)
-      #       results = pool.starmap(computeGradientFV3_Private, zip(repeat(NC), repeat(NP), range(NC), repeat(varField), repeat(varCon), repeat(varCoords), repeat(varStenDex), repeat(radius), repeat(cellCoords)))
-      #       pool.close()
-      #       pool.join()
-      #       #print(results)
-      #       varGradient = np.reshape(np.array(results, dtype='f8').T, (nc, varField.shape[0]))
-      #       #areaD  = np.array(results, dtype='f8')[:, 1]
-
-      #       # print(varGradient)
-
-      #       return varGradient
-
-

--- a/computeGradientFV3.py
+++ b/computeGradientFV3.py
@@ -15,7 +15,7 @@ Parameterized flux integral assumes constant radius and field value.
 import numpy as np
 import math as mt
 from computeAreaIntegral import computeAreaIntegral
-from computeCentroid import computeCentroid
+import computeSphericalCartesianTransforms as sphcrt
 
 import multiprocessing
 from multiprocessing import Process
@@ -141,15 +141,8 @@ def computeGradientFV3(varField, varCon, varCoords, varStenDex):
     # areaD = np.zeros(NC, dtype=SF)
     
     # Precompute the cell centroid map
-    cellCoords = np.zeros((nc,NC), dtype=SF)
-    radius = np.zeros((NC,1), dtype=SF)
-    for jj in range(NC):
-          #pdex = np.array(range(NP), dtype = int)
-          cdex = (varCon[jj,:]) - 1
-          cdex = cdex.astype(int)
-          cell = varCoords[:,cdex]
-          cellCoords[:,jj] = computeCentroid(NP, cell)
-          radius[jj] = np.linalg.norm(cellCoords[:,jj])
+    cellCoords = sphcrt.computeCentroids(varCon, varCoords)
+    radius = np.linalg.norm(cellCoords, axis=1)
     
     # Loop over each cell and get cell average
     pool = multiprocessing.Pool(processes=64)


### PR DESCRIPTION
This PR includes changes that enable full parallelization of the gradient computation for H_1 and H_{0.5} norm calculations. I have introduced a new class to contain the datastructures which can be pre-computed at the start of the metrics computation phase. Then, for all variables and remap iterations, the same datastructures are reused to assemble gradient data.

We have one object for the source and target grid to enable this. I have verified on single/multiple process and also compared against the master version for actual accuracy (which is unchanged).

The performance of the initial precomputation is comparable to a single gradient evaluation from before. However, subsequent gradient calculations are about a factor of 15 faster (on 4 processes - MacBook Pro) on this new branch. 